### PR TITLE
[iOS] Fix Airplay logo appearing when the volume manager is active

### DIFF
--- a/ios/VolumeManager.m
+++ b/ios/VolumeManager.m
@@ -26,6 +26,7 @@
 
 - (void)initVolumeView {
   volumeView = [[MPVolumeView alloc] init];
+  volumeView.transform = CGAffineTransformMakeScale(0.1, 0.1);
   [self showVolumeUI:YES];
   for (UIView *view in volumeView.subviews) {
     if ([view.class.description isEqualToString:@"MPVolumeSlider"]) {


### PR DESCRIPTION
# Why 

Fixes #10 

# How

Added a fix to scale down the native volume view so that the airplay logo doesn't randomly appear in the top left of the screen.

# Testing

So to replicate this issue on the example project, I needed to add a `SafeAreaView` to the `App.tsx` and set the `backgroundColor` to black. Once this was done and you hit the "Hide Native UI" button the icon appears in the top left (screenshot attached). 

All functionality on the screen works the same as before.