### PR TITLE
Upgrade kotlin version to 1.8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
-  def kotlin_version = "1.6.20"
+  def kotlin_version = "1.8.0"
 
   repositories {
     google()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-VolumeManager_kotlinVersion=1.6.20
+VolumeManager_kotlinVersion=1.8.0
 VolumeManager_compileSdkVersion=33
 VolumeManager_targetSdkVersion=33
 


### PR DESCRIPTION
As of expo 49, expo modules use Gradle 8. Which makes the library fail to try to build an Android app. Check: #18 

![image](https://github.com/hirbod/react-native-volume-manager/assets/18466484/9559ad1a-ee55-47b9-9827-571294daa7ce)

