### PR TITLE
fix: prevent onDestroy when back is clicked

### DIFF
--- a/android/src/main/java/com/reactnativevolumemanager/VolumeManagerModule.java
+++ b/android/src/main/java/com/reactnativevolumemanager/VolumeManagerModule.java
@@ -293,9 +293,11 @@ public class VolumeManagerModule
   private void cleanupKeyListener() {
     runOnUiThread(() -> {
       if (!hardwareButtonListenerRegistered) return;
-      View rootView =
-        ((ViewGroup) mContext.getCurrentActivity().getWindow().getDecorView());
-      rootView.setOnKeyListener(null);
+      if (mContext.getCurrentActivity() != null) {
+        View rootView =
+          ((ViewGroup) mContext.getCurrentActivity().getWindow().getDecorView());
+        rootView.setOnKeyListener(null);
+      }
       hardwareButtonListenerRegistered = false;
     });
   }


### PR DESCRIPTION
when having native with a react native fragment, after entering that fragment and then using the back hardware, the app crashes