### PR TITLE
Prevent possible crash when invoking a method on null object reference

### DIFF
--- a/android/src/main/java/com/reactnativevolumemanager/VolumeManagerModule.java
+++ b/android/src/main/java/com/reactnativevolumemanager/VolumeManagerModule.java
@@ -86,12 +86,14 @@ public class VolumeManagerModule
 
   private void setupKeyListener() {
     runOnUiThread(() -> {
+      if (hardwareButtonListenerRegistered) return;
+      if (mContext.getCurrentActivity() == null) return;
+
       View rootView =
         ((ViewGroup) mContext.getCurrentActivity().getWindow().getDecorView());
       rootView.setFocusableInTouchMode(true);
       rootView.requestFocus();
 
-      if (hardwareButtonListenerRegistered) return;
 
       rootView.setOnKeyListener((v, keyCode, event) -> {
         hardwareButtonListenerRegistered = true;
@@ -293,6 +295,8 @@ public class VolumeManagerModule
   private void cleanupKeyListener() {
     runOnUiThread(() -> {
       if (!hardwareButtonListenerRegistered) return;
+      if (mContext.getCurrentActivity() == null) return;
+      
       View rootView =
         ((ViewGroup) mContext.getCurrentActivity().getWindow().getDecorView());
       rootView.setOnKeyListener(null);


### PR DESCRIPTION
Fix for `NullPointerException: Attempt to invoke virtual method 'android.view.Window android.app.Activity.getWindow()' on a null object reference`