### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ Using Yarn:
 yarn add react-native-volume-manager
 ```
 
+### Android Only
+Update the `kotlin_version` to `1.8.0` or higher. Open the `/android/build.gradle` file and modify it as shown below:
+
+```gradle
+buildscript {
+    ext {
+        ...
+        kotlin_version = '1.8.0'
+    }
+}
+repositories {
+    ...
+}
+dependencies {
+    ...
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
+}
+```
+
 For React Native >= 0.60, manual linking is not required with Autolinking.
 
 > Note: This library is incompatible with Expo Go. To use it, you can install a [custom development client](https://docs.expo.dev/develop/development-builds/create-a-build/) as recommended in 2023.


### PR DESCRIPTION
Mentioning the minimum version of `kotlin` in ReadME.md can save a lot. 