### PR TITLE
Enable compatibility with the new Architecture and React Native 0.76

### DIFF
--- a/ios/VolumeManager.m
+++ b/ios/VolumeManager.m
@@ -192,8 +192,6 @@ RCT_EXPORT_METHOD(getVolume
   });
 }
 
-RCT_EXTERN_METHOD(setMuteListenerInterval : (nonnull NSNumber *)newInterval)
-
 RCT_EXPORT_METHOD(enable : (BOOL)enabled async : (BOOL)async) {
   if (async) {
     dispatch_async(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export * from './native';
 export * from './hooks';
 export * from './types';
+
+import VolumeManager from './native';
+export default VolumeManager;


### PR DESCRIPTION
The `setMuteListenerInterval` method was unused and it's body was not defined which caused a crash when TurboModules are enabled.

Additionally I've explicitly re-exported the default export from `native.ts` in the `index.ts` file as calling methods on the default export wasn't working on the new architecture.