### PR TITLE
Fix Android focus crash when app resumes

### DIFF
--- a/android/src/main/java/com/reactnativevolumemanager/VolumeManagerModule.java
+++ b/android/src/main/java/com/reactnativevolumemanager/VolumeManagerModule.java
@@ -106,6 +106,7 @@ public class VolumeManagerModule extends ReactContextBaseJavaModule implements A
 
       Activity activity = mContext.getCurrentActivity();
       View contentView = activity.findViewById(android.R.id.content);
+      if (contentView == null) return;
 
       // Handles focus changes between TextInputs and other views
       // Restores volume key functionality when leaving TextInput
@@ -113,7 +114,7 @@ public class VolumeManagerModule extends ReactContextBaseJavaModule implements A
         @Override
         public void onGlobalFocusChanged(View oldFocus, View newFocus) {
           if (oldFocus instanceof EditText && !(newFocus instanceof EditText)) {
-            contentView.requestFocus();
+            safelyRequestFocus(contentView);
           }
         }
       };
@@ -121,7 +122,7 @@ public class VolumeManagerModule extends ReactContextBaseJavaModule implements A
       contentView.getViewTreeObserver().addOnGlobalFocusChangeListener(globalFocusListener);
       contentView.setOnKeyListener(null);  // Clear any existing listeners
       contentView.setFocusableInTouchMode(true);
-      contentView.requestFocus();
+      safelyRequestFocus(contentView);
 
       // Handle volume key events when native UI is hidden
       contentView.setOnKeyListener((v, keyCode, event) -> {
@@ -171,6 +172,34 @@ public class VolumeManagerModule extends ReactContextBaseJavaModule implements A
       contentView.setOnKeyListener(null);
       hardwareButtonListenerRegistered = false;
     });
+  }
+
+  /**
+   * Requests focus defensively to avoid OEM/framework crashes during accessibility traversal.
+   */
+  private void safelyRequestFocus(View view) {
+    if (view == null || !view.isAttachedToWindow()) return;
+    try {
+      view.requestFocus();
+    } catch (IllegalArgumentException e) {
+      Log.w(TAG, "Ignoring focus request crash in VolumeManagerModule", e);
+    } catch (RuntimeException e) {
+      Log.w(TAG, "Ignoring runtime focus failure in VolumeManagerModule", e);
+    }
+  }
+
+  /**
+   * Clears focus defensively to avoid OEM/framework crashes during accessibility traversal.
+   */
+  private void safelyClearFocus(View view) {
+    if (view == null || !view.isAttachedToWindow()) return;
+    try {
+      view.clearFocus();
+    } catch (IllegalArgumentException e) {
+      Log.w(TAG, "Ignoring clearFocus crash in VolumeManagerModule", e);
+    } catch (RuntimeException e) {
+      Log.w(TAG, "Ignoring runtime clearFocus failure in VolumeManagerModule", e);
+    }
   }
 
   // React Native methods
@@ -352,8 +381,8 @@ public class VolumeManagerModule extends ReactContextBaseJavaModule implements A
       Activity activity = mContext.getCurrentActivity();
       if (activity != null) {
         View contentView = activity.findViewById(android.R.id.content);
-        contentView.clearFocus();  // Clear existing focus
-        contentView.requestFocus();  // Request fresh focus
+        safelyClearFocus(contentView);  // Clear existing focus defensively
+        safelyRequestFocus(contentView);  // Request fresh focus defensively
       }
     });
     hardwareButtonListenerRegistered = false;  // Force re-setup of listeners

--- a/android/src/main/java/com/reactnativevolumemanager/VolumeManagerModule.java
+++ b/android/src/main/java/com/reactnativevolumemanager/VolumeManagerModule.java
@@ -101,6 +101,7 @@ public class VolumeManagerModule extends ReactContextBaseJavaModule implements A
    */
   private void setupKeyListener() {
     runOnUiThread(() -> {
+      if (showNativeVolumeUI) return;
       if (hardwareButtonListenerRegistered) return;
       if (mContext.getCurrentActivity() == null) return;
 
@@ -377,16 +378,18 @@ public class VolumeManagerModule extends ReactContextBaseJavaModule implements A
    */
   @Override
   public void onHostResume() {
-    runOnUiThread(() -> {
-      Activity activity = mContext.getCurrentActivity();
-      if (activity != null) {
-        View contentView = activity.findViewById(android.R.id.content);
-        safelyClearFocus(contentView);  // Clear existing focus defensively
-        safelyRequestFocus(contentView);  // Request fresh focus defensively
-      }
-    });
-    hardwareButtonListenerRegistered = false;  // Force re-setup of listeners
-    setupKeyListener();
+    if (!showNativeVolumeUI) {
+      runOnUiThread(() -> {
+        Activity activity = mContext.getCurrentActivity();
+        if (activity != null) {
+          View contentView = activity.findViewById(android.R.id.content);
+          safelyClearFocus(contentView);  // Clear existing focus defensively
+          safelyRequestFocus(contentView);  // Request fresh focus defensively
+        }
+      });
+      hardwareButtonListenerRegistered = false;  // Force re-setup of listeners
+      setupKeyListener();
+    }
 
     if (volumeMonitoringEnabled) {
       registerVolumeReceiver();


### PR DESCRIPTION
## Summary
- guard focus operations in `VolumeManagerModule` against null/detached content views
- wrap `requestFocus()` and `clearFocus()` in defensive handlers to avoid runtime crashes from OEM/accessibility focus traversal edge cases
- apply the defensive focus helpers in both `setupKeyListener()` and `onHostResume()`
- skip all focus manipulation when `showNativeVolumeUI` is true (the default), preventing unnecessary interference with TextInput focus lifecycle

Fixes #57

## Why
Apps using this module can crash on Android resume with:
`IllegalArgumentException: parameter must be a descendant of this view`

The stack traces point to focus transitions triggered during `onHostResume`. This change keeps behavior intact while avoiding hard crashes when focus state is transient or invalid.

Additionally, when `showNativeVolumeUI` is `true` (the default), the `globalFocusListener` registered in `setupKeyListener()` would call `contentView.requestFocus()` whenever an EditText lost focus — preventing the keyboard from dismissing when a TextInput unmounts (#57). The `showNativeVolumeUI` guard now prevents this entirely.

## Test Plan
- [x] Build Android app with module patched
- [x] Resume app repeatedly (background -> foreground)
- [x] Confirm no crash from `requestFocus` / accessibility traversal
- [x] Verify hardware volume key handling still works with hidden native volume UI
- [x] Verify keyboard dismisses correctly when TextInput unmounts (fixes #57)