### PR TITLE
Fix package build TypeScript scope

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,20 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
+    "rootDir": ".",
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext",
     "types": [
       "jest"
     ]
-  }
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "example",
+    "lib",
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

- scope the root TypeScript project to package sources only
- exclude the standalone example app from Bob declaration builds
- keep the generated declaration layout stable with an explicit `rootDir`

## Why

CI installs the root package dependencies and runs `bob build`. Since the root `tsconfig.json` did not define an `include`, TypeScript picked up `example/App.tsx` and failed on example-only dependencies such as `react-native-safe-area-context` and `@react-native-community/slider`.

## Validation

- `yarn build`
- `yarn typescript`
- `yarn lint`
- `yarn test --runInBand`
